### PR TITLE
added route for deck view & adding cards

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -1,7 +1,15 @@
 import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
 import "./App.css";
 
-import { Home, Login, Signup, CreateDeck, FinishDeckSetup } from "./views";
+import {
+  Home,
+  Login,
+  Signup,
+  CreateDeck,
+  FinishDeckSetup,
+  DeckView,
+  CreateCard,
+} from "./views";
 
 function App() {
   return (
@@ -38,6 +46,12 @@ function App() {
         </Route>
         <Route path="/finishdeck">
           <FinishDeckSetup />
+        </Route>
+        <Route exact path="/deck/:id">
+          <DeckView />
+        </Route>
+        <Route path="/deck/:id/add">
+          <CreateCard />
         </Route>
       </Switch>
     </Router>

--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -1,0 +1,15 @@
+import { useParams, NavLink } from "react-router-dom";
+
+function DeckView() {
+  let { id } = useParams();
+  console.log({ id });
+
+  return (
+    <div>
+      {" "}
+      <h1>this is a deck with id={id}</h1>{" "}
+      <NavLink to={`${id}/add`}>Add Card</NavLink>
+    </div>
+  );
+}
+export default DeckView;

--- a/front-end/src/views/card-creation/CreateCard.jsx
+++ b/front-end/src/views/card-creation/CreateCard.jsx
@@ -1,0 +1,16 @@
+import { NavLink } from "react-router-dom";
+import { CardEditor } from "../../common";
+
+function CreateCard() {
+  return (
+    <div>
+      <h1>Create Your Card</h1>
+      <p>Fill it in!</p>
+      <CardEditor />
+      {/* TODO: style the NavLink to look like a button */}
+      <NavLink to="/finishdeck">Continue</NavLink>
+    </div>
+  );
+}
+
+export default CreateCard;

--- a/front-end/src/views/index.js
+++ b/front-end/src/views/index.js
@@ -1,7 +1,16 @@
 import Login from "./login/Login";
 import Signup from "./signup/Signup";
 import Home from "./home/Home";
+import CreateCard from "./card-creation/CreateCard";
 import CreateDeck from "./create_deck/CreateDeck";
 import FinishDeckSetup from "./finish_deck/FinishDeckSetup";
-
-export { Home, Login, Signup, CreateDeck, FinishDeckSetup };
+import DeckView from "./DeckView";
+export {
+  Home,
+  Login,
+  Signup,
+  CreateCard,
+  CreateDeck,
+  FinishDeckSetup,
+  DeckView,
+};


### PR DESCRIPTION
this PR just adds a couple of routes so that we can align on what routes display what
- pokedek.com/deck/<deckid> will be the page that people can view the deck and add cards from 
- pokedek.com/deck/<deckid>/add will be the page where people can add cards to the deck with id <deckid>

there's no way to get to the links via web interaction yet so you can just directly type in the link e.g. http://localhost:3000/deck/123