### PR TITLE
update approach to state mgmt in creation flows

### DIFF
--- a/front-end/src/common/account-prompt-modal/AccountPromptModal.css
+++ b/front-end/src/common/account-prompt-modal/AccountPromptModal.css
@@ -1,7 +1,3 @@
-.TextInput + .TextInput {
-  margin-top: 1em;
-}
-
 .AccountPromptModal {
   position: fixed;
   left: 0;
@@ -24,39 +20,4 @@
 
 .AccountPromptModal__title {
   margin: 0;
-}
-
-.AccountPromptModal__footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-top: 4em;
-}
-
-.nakedLink {
-  text-decoration: none;
-}
-
-.AccountPromptModal__link {
-  color: black;
-}
-.AccountPromptModal__link:hover {
-  cursor: pointer;
-  color: #396bba;
-}
-
-.AccountPromptModal__cta {
-  background-color: #396bba;
-  padding: 0.25em 1em;
-  border-radius: 0.5em;
-  color: white;
-  cursor: pointer;
-}
-
-.AccountPromptModal__cta:hover {
-  background-color: #2e5695;
-  padding: 0.25em 1em;
-  border-radius: 0.5em;
-  color: white;
-  cursor: pointer;
 }

--- a/front-end/src/common/account-prompt-modal/AccountPromptModal.jsx
+++ b/front-end/src/common/account-prompt-modal/AccountPromptModal.jsx
@@ -1,8 +1,15 @@
 import SignupOrLogin from "./SignupOrLogin";
 import "./AccountPromptModal.css";
 import { useState } from "react";
-function AccountPromptModal({ parentType, onCloseModal }) {
-  const [pageType, setPageType] = useState("Sign up");
+import { MODAL_PAGE_TYPE } from "../../common/constants";
+
+function AccountPromptModal({
+  parentType,
+  onContinueAsGuest,
+  onSignupOrLogin,
+}) {
+  // TODO: close Modal on click outside / click on x
+  const [pageType, setPageType] = useState(MODAL_PAGE_TYPE.SIGNUP);
 
   return (
     <div className="AccountPromptModal">
@@ -19,30 +26,11 @@ function AccountPromptModal({ parentType, onCloseModal }) {
             {parentType}!
           </p>
           <SignupOrLogin
-            onCloseModal={onCloseModal}
+            onContinueAsGuest={onContinueAsGuest}
+            onSignupOrLogin={onSignupOrLogin}
             pageType={pageType}
             setPageType={setPageType}
           />
-        </div>
-        <div className="AccountPromptModal__footer">
-          <a
-            className="AccountPromptModal__link nakedLink"
-            onClick={() => {
-              console.log("continue as guest");
-              onCloseModal();
-            }}
-          >
-            Continue as guest
-          </a>
-          <span
-            className="AccountPromptModal__cta"
-            onClick={() => {
-              console.log("submit");
-              onCloseModal();
-            }}
-          >
-            {pageType}
-          </span>
         </div>
       </div>
     </div>

--- a/front-end/src/common/account-prompt-modal/SignupOrLogin.css
+++ b/front-end/src/common/account-prompt-modal/SignupOrLogin.css
@@ -7,3 +7,42 @@
 .SignupOrLogin__altLink {
   padding-top: 1em;
 }
+
+.SignupOrLogin__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 4em;
+}
+
+.nakedLink {
+  text-decoration: none;
+}
+
+.SignupOrLogin__link {
+  color: black;
+}
+.SignupOrLogin__link:hover {
+  cursor: pointer;
+  color: #396bba;
+}
+
+.SignupOrLogin__cta {
+  background-color: #396bba;
+  padding: 0.25em 1em;
+  border-radius: 0.5em;
+  color: white;
+  cursor: pointer;
+}
+
+.SignupOrLogin__cta:hover {
+  background-color: #2e5695;
+  padding: 0.25em 1em;
+  border-radius: 0.5em;
+  color: white;
+  cursor: pointer;
+}
+
+.TextInput + .TextInput {
+  margin-top: 1em;
+}

--- a/front-end/src/common/account-prompt-modal/SignupOrLogin.jsx
+++ b/front-end/src/common/account-prompt-modal/SignupOrLogin.jsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
+import { MODAL_PAGE_TYPE } from "../constants";
 import TextInput from "../TextInput";
 
 import "./SignupOrLogin.css";
 
-const SignupOrLogin = ({ pageType, setPageType }) => {
+const SignupOrLogin = ({
+  pageType,
+  setPageType,
+  onContinueAsGuest,
+  onSignupOrLogin,
+}) => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -11,7 +17,7 @@ const SignupOrLogin = ({ pageType, setPageType }) => {
   return (
     <div className="SignupOrLogin">
       <h3>{pageType}</h3>
-      {pageType === "Sign up" && (
+      {pageType === MODAL_PAGE_TYPE.SIGNUP && (
         <TextInput
           placeholder="Name"
           value={name}
@@ -28,13 +34,13 @@ const SignupOrLogin = ({ pageType, setPageType }) => {
         value={password}
         onChange={(event) => setPassword(event.target.value)}
       />
-      {pageType === "Sign up" ? (
+      {pageType === MODAL_PAGE_TYPE.SIGNUP ? (
         <i className="SignupOrLogin__altLink">
           Already have an account? Log in{" "}
           <a
-            className="AccountPromptModal__link"
+            className="SignupOrLogin__link"
             onClick={() => {
-              setPageType("Log in");
+              setPageType(MODAL_PAGE_TYPE.LOGIN);
             }}
           >
             here
@@ -44,15 +50,29 @@ const SignupOrLogin = ({ pageType, setPageType }) => {
         <i className="SignupOrLogin__altLink">
           Need to make an account? Sign up{" "}
           <a
-            className="AccountPromptModal__link"
+            className="SignupOrLogin__link"
             onClick={() => {
-              setPageType("Sign up");
+              setPageType(MODAL_PAGE_TYPE.SIGNUP);
             }}
           >
             here
           </a>
         </i>
       )}
+      <div className="SignupOrLogin__footer">
+        <a
+          className="SignupOrLogin__link nakedLink"
+          onClick={onContinueAsGuest}
+        >
+          Continue as guest
+        </a>
+        <span
+          className="SignupOrLogin__cta"
+          onClick={() => onSignupOrLogin(pageType, name, email, password)}
+        >
+          {pageType}
+        </span>
+      </div>
     </div>
   );
 };

--- a/front-end/src/common/card-editor/CardEditor.jsx
+++ b/front-end/src/common/card-editor/CardEditor.jsx
@@ -1,64 +1,25 @@
-import { useState } from "react";
 import "./CardEditor.css";
 import kev from "../../assets/kev.jpeg";
 import heart from "../../assets/heart.png";
 import Slider from "rc-slider";
 import "rc-slider/assets/index.css";
+import { FORM_DEFAULT_PLACEHOLDERS } from "../constants";
 
 const sectionIds = [0, 1, 2];
 
-const formDefaultPlaceholders = {
-  name: "Name Here",
-  city: "NYC",
-  tagline: "~5 word tagline about yourself",
-  summary: "ROLE (# YOE), working hours & time zone",
-  sectionLabel0: "Strengths",
-  sectionLabel1: "Weaknesses",
-  sectionLabel2: "Communication Preferences",
-  sectionContent0: "What do you excel at?",
-  sectionContent1: "What do you struggle with?",
-  sectionContent2: "How do you want people to contact you?",
-  sliderLabelMin: "Introvert",
-  sliderLabelMax: "Extrovert",
-  sliderValue: 50,
-};
-
 const HeartIcon = () => <img src={heart} width="25px" height="25px" />;
 
-function CardEditor({ onSave, templateData }) {
+function CardEditor({ form = {}, setForm, templateData }) {
   const isPopulatingTemplate = templateData !== undefined;
-  const emptyForm = Object.keys(formDefaultPlaceholders).reduce(
-    (prev, curr) => {
-      prev[curr] = "";
-      return prev;
-    },
-    {}
-  );
-
-  const [form, setForm] = useState(emptyForm);
-
-  const handleSubmit = (event) => {
-    event.preventDefault();
-
-    // if creating template, fill in blanks with default vals
-    if (!isPopulatingTemplate) {
-      Object.keys(form).forEach((key) => {
-        if (form[key] === "") {
-          form[key] = formDefaultPlaceholders[key];
-        }
-      });
-    }
-
-    console.log({ form });
-    onSave?.(form);
-  };
 
   const getPlaceholderText = (field) =>
-    isPopulatingTemplate ? templateData[field] : formDefaultPlaceholders[field];
+    isPopulatingTemplate
+      ? templateData[field]
+      : FORM_DEFAULT_PLACEHOLDERS[field];
 
   return (
     <div className="CardEditor">
-      <form className="CardEditor__form" onSubmit={handleSubmit} id="myCard">
+      <form className="CardEditor__form" id="myCard">
         <div className="CardEditor__upperContent">
           <input
             className="CardEditor__tagline"
@@ -209,7 +170,7 @@ function CardEditor({ onSave, templateData }) {
             )}
           </div>
           <Slider
-            defaultValue={formDefaultPlaceholders.sliderValue}
+            defaultValue={FORM_DEFAULT_PLACEHOLDERS.sliderValue}
             handleStyle={{ borderColor: "pink" }}
             railStyle={{ backgroundColor: "pink" }}
             trackStyle={{ backgroundColor: "pink" }}
@@ -222,13 +183,6 @@ function CardEditor({ onSave, templateData }) {
           />
         </div>
       </form>
-      <input
-        className="CardEditor__submit"
-        type="submit"
-        value="Submit"
-        form="myCard"
-        onSubmit={handleSubmit}
-      />
     </div>
   );
 }

--- a/front-end/src/common/constants.js
+++ b/front-end/src/common/constants.js
@@ -1,0 +1,61 @@
+export const MODAL_PAGE_TYPE = { SIGNUP: "Sign up", LOGIN: "Log in" };
+
+export const PARENT_TYPE = { DECK: "deck", CARD: "card" };
+
+export const FORM_DEFAULT_PLACEHOLDERS = {
+  name: "Name Here",
+  city: "NYC",
+  tagline: "~5 word tagline about yourself",
+  summary: "ROLE (# YOE), working hours & time zone",
+  sectionLabel0: "Strengths",
+  sectionLabel1: "Weaknesses",
+  sectionLabel2: "Communication Preferences",
+  sectionContent0: "What do you excel at?",
+  sectionContent1: "What do you struggle with?",
+  sectionContent2: "How do you want people to contact you?",
+  sliderLabelMin: "Introvert",
+  sliderLabelMax: "Extrovert",
+  sliderValue: 50,
+};
+
+export const EMPTY_TEMPLATE = {
+  name: "",
+  city: "",
+  tagline: "",
+  summary: "",
+  sectionLabel0: "",
+  sectionLabel1: "",
+  sectionLabel2: "",
+  sectionContent0: "",
+  sectionContent1: "",
+  sectionContent2: "",
+  sliderLabelMin: "",
+  sliderLabelMax: "",
+  sliderValue: 50,
+};
+
+export const EMPTY_CARD = {
+  name: "",
+  city: "",
+  tagline: "",
+  summary: "",
+  sectionContent0: "",
+  sectionContent1: "",
+  sectionContent2: "",
+  sliderValue: 50,
+};
+
+export const TEST_TEMPLATE_DATA = {
+  name: "Janet Huang",
+  city: "NYC",
+  tagline: "K-drama and dessert enthusiast",
+  summary: "Software Engineer (2 YOE), 9AM-5PM ",
+  sectionLabel0: "Superpowers",
+  sectionLabel1: "Things you suck at",
+  sectionLabel2: "Communication Preferences",
+  sectionContent0: "eating & sleeping",
+  sectionContent1: "speaking",
+  sectionContent2: "never ideally",
+  sliderLabelMin: "me",
+  sliderLabelMax: "we",
+};

--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -1,4 +1,4 @@
-import { useParams, NavLink } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 
 function DeckView() {
   let { id } = useParams();
@@ -7,8 +7,15 @@ function DeckView() {
   return (
     <div>
       {" "}
-      <h1>this is a deck with id={id}</h1>{" "}
-      <NavLink to={`${id}/add`}>Add Card</NavLink>
+      <h1>this is a deck with id={id}</h1>
+      <Link
+        to={{
+          pathname: `${id}/add`,
+          state: { deckId: id }, // passing template data over to the next page
+        }}
+      >
+        Add a card
+      </Link>
     </div>
   );
 }

--- a/front-end/src/views/card-creation/CreateCard.jsx
+++ b/front-end/src/views/card-creation/CreateCard.jsx
@@ -1,47 +1,81 @@
 import { useState } from "react";
-import { NavLink } from "react-router-dom";
 import { CardEditor, AccountPromptModal } from "../../common";
-
-const testTemplateData = {
-  name: "Janet Huang",
-  city: "NYC",
-  tagline: "K-drama and dessert enthusiast",
-  summary: "Software Engineer (2 YOE), 9AM-5PM ",
-  sectionLabel0: "Superpowers",
-  sectionLabel1: "Things you suck at",
-  sectionLabel2: "Communication Preferences",
-  sectionContent0: "eating & sleeping",
-  sectionContent1: "speaking",
-  sectionContent2: "never ideally",
-  sliderLabelMin: "me",
-  sliderLabelMax: "we",
-};
+import { Redirect, useLocation } from "react-router-dom";
+import {
+  EMPTY_CARD,
+  TEST_TEMPLATE_DATA,
+  PARENT_TYPE,
+  MODAL_PAGE_TYPE,
+} from "../../common/constants";
 
 function CreateCard() {
+  let data = useLocation();
+  const deckId = data.state.deckId;
   const [showModal, setShowModal] = useState(false);
+  const [form, setForm] = useState(EMPTY_CARD);
+  const [redirect, setRedirect] = useState(false);
 
-  const onSaveCard = (cardData) => {
-    setShowModal(true);
-    console.log({ cardData });
+  // TODO: get actual template data given deck id
+
+  if (redirect) {
+    return <Redirect to={`/deck/${deckId}`} />;
+  }
+
+  const saveCard = (userId) => {
+    console.log({ form, userId });
+    // save card data to db under deck with deckId
+    // link card to userId if exists (and vice versa)
+    // return cardId
   };
 
-  const onCloseModal = () => {
+  const closeModalWithRedirect = () => {
     setShowModal(false);
+    setRedirect(true);
+  };
+
+  const onContinueAsGuest = () => {
+    const cardId = saveCard();
+    closeModalWithRedirect(cardId);
+  };
+
+  const onSignupOrLogin = (pageType, name, email, password) => {
+    let userId;
+
+    if (pageType === MODAL_PAGE_TYPE.SIGNUP) {
+      // create & save account – get id of newly created account
+    } else {
+      // log user in – get id of existing account
+    }
+
+    const cardId = saveCard(userId);
+    closeModalWithRedirect(cardId);
   };
 
   return (
     <div>
       <h1>Create Your Card</h1>
+      <p>adding to deck with id {deckId}</p>
       <p>Fill it in!</p>
-      <h3>Populating a Template</h3>
-      <CardEditor templateData={testTemplateData} onSave={onSaveCard} />
-      <h3>Creating a Template</h3>
-      <CardEditor onSave={onSaveCard} />
-      {/* TODO: style the NavLink to look like a button */}
-      <NavLink to="/finishdeck">Continue</NavLink>
+      <CardEditor
+        templateData={TEST_TEMPLATE_DATA}
+        form={form}
+        setForm={setForm}
+      />
       {showModal && (
-        <AccountPromptModal parentType="deck" onCloseModal={onCloseModal} />
+        <AccountPromptModal
+          parentType={PARENT_TYPE.CARD}
+          onCloseModal={() => setShowModal(false)}
+          onContinueAsGuest={onContinueAsGuest}
+          onSignupOrLogin={onSignupOrLogin}
+        />
       )}
+      <div
+        onClick={(event) => {
+          setShowModal(true);
+        }}
+      >
+        Continue
+      </div>
     </div>
   );
 }

--- a/front-end/src/views/create_deck/CreateDeck.jsx
+++ b/front-end/src/views/create_deck/CreateDeck.jsx
@@ -1,11 +1,11 @@
-import { NavLink } from "react-router-dom";
-
+import { useState } from "react";
+import { Link } from "react-router-dom";
 import CardEditor from "../../common/card-editor/CardEditor";
-
-/* TODO: implement onSave function passed to CardEditor */
-function onSave() {}
+import { EMPTY_TEMPLATE } from "../../common/constants";
 
 function CreateDeck() {
+  const [form, setForm] = useState(EMPTY_TEMPLATE);
+
   return (
     <div>
       <h1>Create a New Deck</h1>
@@ -13,9 +13,16 @@ function CreateDeck() {
         Edit the card below to capture information that’s important to your
         team. This template card will be shared with your teammates.
       </p>
-      <CardEditor onSave={onSave} />
-      {/* TODO: style the NavLink to look like a button */}
-      <NavLink to="/finishdeck">Continue</NavLink>
+      <CardEditor form={form} setForm={setForm} />
+      {/* TODO: style the Link to look like a button */}
+      <Link
+        to={{
+          pathname: "/finishdeck",
+          state: { templateData: form }, // passing template data over to the next page
+        }}
+      >
+        Finalize deck details
+      </Link>
     </div>
   );
 }

--- a/front-end/src/views/finish_deck/FinishDeckSetup.jsx
+++ b/front-end/src/views/finish_deck/FinishDeckSetup.jsx
@@ -1,17 +1,59 @@
 import DeckEditor from "../../common/deck-editor/DeckEditor";
 import AccountPromptModal from "../../common/account-prompt-modal/AccountPromptModal";
-
+import { useLocation } from "react-router-dom";
 import { useState } from "react";
+import {
+  FORM_DEFAULT_PLACEHOLDERS,
+  MODAL_PAGE_TYPE,
+  PARENT_TYPE,
+} from "../../common/constants";
 
 function FinishDeckSetup() {
+  let data = useLocation();
+
   const [deckName, setDeckName] = useState("");
   const [deckDescription, setDeckDescription] = useState("");
   const [showModal, setShowModal] = useState(false);
 
-  const onCloseModal = () => {
-    console.log(deckName, deckDescription);
-    /* TODO: mock API for saving data */
+  const saveDeck = (userId) => {
+    // user-entered template data would be contained in data.state.templateData
+    // we want to fill in blanks with default vals
+    const templateData = data.state.templateData;
+    Object.keys(templateData).forEach((key) => {
+      if (templateData[key] === "") {
+        templateData[key] = FORM_DEFAULT_PLACEHOLDERS[key];
+      }
+    });
+
+    console.log({ templateData });
+
+    // TODO: save deck data (updatedTemplate, name, desc)
+    // link deck to userId if exists (and vice versa)
+
+    // return id of newly created deck
+  };
+
+  const closeModalWithRedirect = (deckId) => {
     setShowModal(false);
+    // TODO: redirect to newly created deck page given deckId
+  };
+
+  const onContinueAsGuest = () => {
+    const deckId = saveDeck();
+    closeModalWithRedirect(deckId);
+  };
+
+  const onSignupOrLogin = (pageType, name, email, password) => {
+    let userId;
+
+    if (pageType === MODAL_PAGE_TYPE.SIGNUP) {
+      // TODO: create & save account – get id of newly created account
+    } else {
+      // TODO: log user in – get id of existing account
+    }
+
+    const deckId = saveDeck(userId);
+    closeModalWithRedirect(deckId);
   };
 
   return (
@@ -24,7 +66,11 @@ function FinishDeckSetup() {
         setDeckDescription={setDeckDescription}
       />
       {showModal ? (
-        <AccountPromptModal parentType="deck" onCloseModal={onCloseModal} />
+        <AccountPromptModal
+          parentType={PARENT_TYPE.DECK}
+          onContinueAsGuest={onContinueAsGuest}
+          onSignupOrLogin={onSignupOrLogin}
+        />
       ) : null}
       <button
         onClick={(event) => {


### PR DESCRIPTION
This PR should not result in any visual changes; it instead simplifies state management in the creation flows. The key thing to note is that state has been lifted out of the CardEditor and that data is being passed between pages using the `state` prop of `<Link>` (some documentation [here](https://reactrouter.com/web/api/Link/to-object)).

I also created a new file for tracking constants – this is very much a WIP and should be updated to include things like colors.