### PR TITLE
updating account page with endpoints and a few style changes

### DIFF
--- a/front-end/src/views/account_page/AccountPage.css
+++ b/front-end/src/views/account_page/AccountPage.css
@@ -24,7 +24,7 @@
 }
 
 .title {
-    font-size: 40px;
+    font-size: 35px;
     font-weight: bold;
     text-decoration: none;
     color: black;
@@ -58,4 +58,8 @@
   grid-column-end: 3;
   justify-self: start;
   border-radius: 0px 20px 20px 0px;
+}
+
+.deck {
+  text-align: center;
 }

--- a/front-end/src/views/account_page/AccountPage.jsx
+++ b/front-end/src/views/account_page/AccountPage.jsx
@@ -15,35 +15,99 @@ function AccountPage() {
 //make states an object and the page-displayed state variable a string (with its values as the keys of the states object) for clarity later
     const states = ["Active", "inactive"]; //array for defining classes of button states
 
-
+    //let { id } = useParams();
     let { id } = useParams();
-    console.log({ id });
     let pageContent;
+    let pageElement;
     const [deckActive, setDeckActive] = useState(0); 
     //0 = mydeck view, 1 = joinedcard view (for easy class switching for styling and content display using states array)
 
-    const [templateArray, setTemplateData] = useState([]);
-    const [deckTitle, setDeckName] = useState();
-    const [deckSubtitle, setDeckDescription] = useState();
+    const [ownedDeckNamesArray, setOwnedDeckNameData] = useState([]);
+    const [ownedDeckIdsArray, setOwnedDeckIdData] = useState([]);
+    const [ownedCardsArray, setOwnedCardsData] = useState([]); //user cards in owned decks
+    const [joinedDeckNamesArray, setJoinedDeckNameData] = useState([]);
+    const [joinedDeckIdsArray, setJoinedDeckIdData] = useState([]);
+    const [joinedCardsArray, setJoinedCardsData] = useState([]); //user cards in joined decks
 
-  useEffect(() => {
-    axios
-      .get(`https://my.api.mockaroo.com/deck/123?key=d5aa71f0`)
-      .then((response) => {
-        console.log("data", response.data.cards);
-        setTemplateData(response.data.cards);
-        setDeckName(response.data.deckName);
-        setDeckDescription(response.data.deckDescription);
-        setIsDeckLoaded(true);
-      })
-      .catch((err) => {
-        console.log("!!", err);
-        setTemplateData(TEST_CARDS_ARRAY);
-        setDeckName("SWE");
-        setDeckDescription("Team for SWE Project, Fall 2021");
-        setIsDeckLoaded(true);
-      })
-  }, []);
+    useEffect(() => {
+      axios
+        .get(`http://localhost:8000/user/${id}`)
+        .then((response) => {
+          setIsDeckLoaded(true);
+          let userDecks = response.data.users.decks;
+          let userCards = response.data.users.cards;
+
+          let ownedTitles = [];
+
+          //finds all users owned decks
+          for (const id in userDecks) {
+            ownedTitles.push(response.data.decks[userDecks[id]].deckName);
+          }
+
+          let ownedCards = [];
+
+          for (const id in userDecks) {
+            //checks for matching cards to have corresponding cards and decks in same position of arrays for display
+            let cardNum = 0;
+            while (response.data.cards[userCards[cardNum]].deckId !== userDecks[id]){
+              cardNum++;
+            }
+            ownedCards.push(response.data.cards[userCards[cardNum]]);
+          }
+
+          let joinedCards = [];
+
+          for (const id in userCards) {
+            //checks if card is already included in ownedCards
+            let isOwned = false;
+            for (const count in ownedCards) {
+              if (userCards[id] === ownedCards[count]) {
+                isOwned = true;
+                break;
+              }
+            }
+            if (!isOwned){
+              joinedCards.push(response.data.cards[userCards[id]]);
+            }
+          }
+
+        let joinedDecks = [];
+        let joinedIds = [];
+
+        for (const id in joinedCards) {
+          //finds corresponding deck names for owned cards that aren't in owned decks
+          joinedDecks.push(response.data.decks[joinedCards[id].deckId].deckName);
+          joinedIds.push(joinedCards[id].deckId);
+        }
+
+          setOwnedDeckNameData(ownedTitles);
+          setOwnedDeckIdData(userDecks);
+          setOwnedCardsData(ownedCards);
+          setJoinedDeckNameData(joinedDecks);
+          setJoinedDeckIdData(joinedIds);
+          setJoinedCardsData(joinedCards);
+        })
+        .catch((err) => {
+          console.log("!!", err);
+          setOwnedDeckNameData(["Painters", "Pokemon", "Pop Stars", "Rich People", "Missing"]);
+          setOwnedDeckIdData(["123", "123", "123", "123", "123"]);
+          setOwnedCardsData(TEST_CARDS_ARRAY);
+          setJoinedDeckNameData(["Nice Guys", "Nintendo Mascots", "The Voice", "University Presidents", "Unknowns"]);
+          setJoinedDeckIdData(["123", "123", "123", "123", "123"]);
+          setJoinedCardsData(TEST_CARDS_ARRAY);
+          setIsDeckLoaded(true);
+        });
+        //Cleanup function to avoid warning/errors.
+        return () => {
+          setIsDeckLoaded(false);
+          setOwnedDeckNameData();
+          setOwnedDeckIdData();
+          setOwnedCardsData();
+          setJoinedDeckNameData();
+          setJoinedDeckIdData();
+          setJoinedCardsData();
+        }
+    }, []);
 
 //onClick functions for changing state for display
     const activateMyDeckView = () =>{
@@ -54,24 +118,36 @@ function AccountPage() {
         setDeckActive(1);
     }
 
-/*defines page content (either cards or decks)
-  TO DO: update with actual card and deck display once DeckView and DisplayCard are updated,
-    will use arrays to display multiple cards/decks when user functionality is further along */
+    //<DisplayCard tempArray={ownedCardsArray[i]}></DisplayCard>
+//defines page content (either cards or decks)
+
+    const ownedContent = [];
+    const joinedContent = [];
+
+    for(let i = 0; i < ownedDeckNamesArray.length; i++){
+      pageElement = <><div className="deck"><NavLink to={`deck/${ownedDeckIdsArray[i]}`} className="title">{ownedDeckNamesArray[i]}</NavLink>
+      <DisplayCard tempArray={ownedCardsArray[i]}></DisplayCard>
+      </div>
+      </>;
+      ownedContent.push(pageElement);
+    }
+
+    for(let i = 0; i < joinedDeckNamesArray.length; i++){
+      pageElement = <><div className="deck"><NavLink to={`deck/${joinedDeckIdsArray[i]}`} className="title">{joinedDeckNamesArray[i]}</NavLink>
+      <DisplayCard tempArray={joinedCardsArray[i]}></DisplayCard>
+      </div>
+      </>;
+      joinedContent.push(pageElement);
+    }
+    
     if(deckActive === 0){
-        pageContent = <><NavLink to={`deck/${id}`} className="title">{deckTitle}</NavLink>
-        <h2 className="subtitle">{deckSubtitle}</h2>
-        <div className="displayedCard">
-          <DisplayCard tempArray={templateArray[0]}></DisplayCard>
-        </div></>;
-        
+        pageContent = ownedContent;
     }
     else{
-        pageContent = <><NavLink to={`deck/${id}`} className="title">{deckTitle}</NavLink>
-        <h2 className="subtitle">{deckSubtitle}</h2>
-        <div className="displayedCard">
-          <DisplayCard tempArray={templateArray[1]}></DisplayCard>
-          </div></>;
+        pageContent = joinedContent;
     }
+    
+
     return !isDeckLoaded ? (
       <LoadingSpinner />
     ) :(
@@ -80,7 +156,9 @@ function AccountPage() {
           <button className={states[deckActive]} id="myDeckView" onClick={activateMyDeckView} type="button">Owned Decks</button>
           <button className={states[1-deckActive]} id="joinedDeckView" onClick={activateJoinedDeckView} type="button">Joined Decks</button>
         </div>
+          <div className="deck-list">
             {pageContent}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
Made some updates to the account page, but the current way I'm getting data seems kind of complicated so if you can see a much smarter, easier way please let me know!!! Also for now I have it displaying just deck name and the user's card for each deck, but if you have layout suggestions you think would be more user friendly let me know as well.

![accountpage](https://user-images.githubusercontent.com/60206755/140678400-08307fe4-4bb1-4bde-b5d3-48f0c260be35.png)
