### PR TITLE
update share text & account page styling

### DIFF
--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -10,7 +10,11 @@ import share from "../assets/share.png";
 function DeckView() {
   let { id } = useParams();
   const [isDeckLoaded, setIsDeckLoaded] = useState(false);
-  const [deck, setDeck] = useState({deckName: "Untitled", deckDescription: "", cards: []});
+  const [deck, setDeck] = useState({
+    deckName: "Untitled",
+    deckDescription: "",
+    cards: [],
+  });
 
   useEffect(() => {
     axios
@@ -32,7 +36,7 @@ function DeckView() {
       .then(() => {
         //After deleting, redirect user back to homepage.
         alert("You've just deleted a deck!");
-        window.location.href = "http://localhost:3000"
+        window.location.href = "http://localhost:3000";
       })
       .catch((err) => {
         console.log("!!", err);
@@ -42,7 +46,8 @@ function DeckView() {
   function shareDeck() {
     // TODO: Have url copied for user when click on button!
 
-    document.getElementById("shared-text").innerHTML = "Copied share link!";
+    document.getElementById("shared-text").innerHTML =
+      "Copied deck access code!";
     setTimeout(function () {
       document.getElementById("shared-text").innerHTML = "";
     }, 3000);

--- a/front-end/src/views/account_page/AccountPage.css
+++ b/front-end/src/views/account_page/AccountPage.css
@@ -1,39 +1,40 @@
-.toggles{
-    width: 100px;
-    border: none;
+.toggles {
+  width: 100px;
+  border: none;
 }
 
-#myDeckView, #joinedDeckView{
-    height: 50px;
-    width: 200px;
+#myDeckView,
+#joinedDeckView {
+  height: 50px;
+  width: 200px;
 }
 
-.Active{
-    background-color: #396bba;
-    color: white;
-    border: none;
-    font-size: 30px;
+.Active {
+  background-color: #396bba;
+  color: white;
+  border: none;
+  font-size: 30px;
 }
 
-.inactive{
-    background-color: white;
-    color: #396bba;
-    border: 1px solid;
-    border-color: #396bba;
-    font-size: 30px;
+.inactive {
+  background-color: white;
+  color: #396bba;
+  border: 1px solid;
+  border-color: #396bba;
+  font-size: 30px;
 }
 
 .deckLink {
-    font-size: 35px;
-    font-weight: bold;
-    text-decoration: none;
-    color: black;
-  }
+  font-size: 35px;
+  font-weight: bold;
+  text-decoration: none;
+  color: black;
+}
 
-  .subtitle {
-    font-size: 20px;
-    font-weight: bold;
-  }
+.subtitle {
+  font-size: 20px;
+  font-weight: bold;
+}
 
 .deck-list {
   display: flex;
@@ -45,6 +46,7 @@
 .toggle-switch {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  margin-bottom: 3em;
 }
 
 #myDeckView {

--- a/front-end/src/views/account_page/AccountPage.jsx
+++ b/front-end/src/views/account_page/AccountPage.jsx
@@ -150,7 +150,7 @@ function AccountPage({ token }) {
   const page = !isDeckLoaded ? (
     <LoadingSpinner />
   ) : (
-    <div className="container">
+    <div>
       <div className="toggle-switch">
         <button
           className={states[deckActive]}


### PR DESCRIPTION
this PR ensures that accountpage can render up to 3 cards/row and updates the share link text from copied link to copied code
<img width="1341" alt="Screen Shot 2021-11-16 at 6 09 30 PM" src="https://user-images.githubusercontent.com/52385987/142080877-0bfeed2a-6c8d-4285-92b3-b3cbbd3a9f03.png">
<img width="346" alt="Screen Shot 2021-11-16 at 6 09 59 PM" src="https://user-images.githubusercontent.com/52385987/142080885-3f0af89a-afae-4609-bfd7-be94fbc31bfb.png">
