### PR TITLE
implemented infinite scrolling with paginated GET deck endpoint

### DIFF
--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -30,8 +30,6 @@ function DeckView() {
   }
 
   function fetchMoreCards() {
-    console.log("Fetching more cards from backend");
-    console.log("Current Deck:", deck);
     axios
       .get(`http://localhost:8000/deck/${id}?page=${page}&limit=${CARD_LIMIT}`)
       .then((res) => {

--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -43,7 +43,6 @@ function DeckView() {
         });
         // increment the page by 1
         setPage(page + 1);
-        console.log("Paginated Response:", res.data);
       });
   }
 
@@ -53,7 +52,6 @@ function DeckView() {
     axios
       .get(`http://localhost:8000/deck/${id}?page=${page}&limit=${CARD_LIMIT}`)
       .then((res) => {
-        console.log("res", res.data);
         setIsDeckLoaded(true);
         setDeck(res.data);
         setPage(page + 1);


### PR DESCRIPTION
as title. 

on the FE added infinite scrolling to the deck view page. will load 9 cards initially, and when the user scrolls to the bottom of the page, it will will continue to load in cards in batches of 9 until there are no more cards left. for now, the cards are sorted alphabetically by name. 

on the BE tweaked the GET deck endpoint to be paginated. also modified how we're querying Mongo to join (populate) the deck card Ids with card objects, sort the card array by name, skip a specified num of documents, and limit the num of documents returned. 

to see it working, I created an deck to demo infinite scrolling with the access code: srMj-PGlb