### PR TITLE
conditionally render/enable buttons in deckview

### DIFF
--- a/back-end/controllers/deckController.js
+++ b/back-end/controllers/deckController.js
@@ -39,6 +39,24 @@ const getDeckDetails = async (req, res, next) => {
   res.json(deck);
 };
 
+const getDeckPermissions = async (req, res, next) => {
+  const deck = await Deck.findById(req.params.deckId).catch((err) => {
+    next(err);
+  });
+  const isDeckOwner = req.user._id.equals(deck.ownerId);
+
+  const cardIds = deck.cards;
+  const card = await Card.findOne({
+    _id: { $in: cardIds },
+    userId: req.user._id,
+  }).catch((err) => {
+    next(err);
+  });
+  const canAddCard = card === null;
+
+  res.json({ isDeckOwner, canAddCard });
+};
+
 const getDeck = async (req, res, next) => {
   const deckId = req.params.deckId;
   const page = parseInt(req.query.page);
@@ -185,6 +203,7 @@ module.exports = {
   getDeckDetails,
   getAccessCodes,
   getDeckTemplate,
+  getDeckPermissions,
   getDeck,
   createDeck,
   updateDeck,

--- a/back-end/routes/deckRoutes.js
+++ b/back-end/routes/deckRoutes.js
@@ -1,3 +1,4 @@
+const passport = require("passport");
 const express = require("express");
 const router = express.Router();
 const deckController = require("../controllers/deckController");
@@ -9,6 +10,12 @@ router.get("/accessCodes", deckController.getAccessCodes);
 router.get("/deckTemplate/:deckId", deckController.getDeckTemplate);
 
 router.get("/deckDetails/:deckId", deckController.getDeckDetails);
+
+router.get(
+  "/deckPermissions/:deckId",
+  passport.authenticate("jwt", { session: false }),
+  deckController.getDeckPermissions
+);
 
 router.get("/:deckId", deckController.getDeck);
 
@@ -22,9 +29,14 @@ router.post(
 router.patch(
   "/:deckId",
   body("deckName", "Deck name is required").notEmpty(),
+  passport.authenticate("jwt", { session: false }),
   deckController.updateDeck
 );
 
-router.delete("/:deckId", deckController.deleteDeck);
+router.delete(
+  "/:deckId",
+  passport.authenticate("jwt", { session: false }),
+  deckController.deleteDeck
+);
 
 module.exports = router;

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -64,10 +64,10 @@ function App() {
               <FinishDeckSetup token={token} setToken={setToken} />
             </Route>
             <Route path="/deck/:deckId/edit">
-              <UpdateDeck />
+              <UpdateDeck token={token} />
             </Route>
             <Route exact path="/deck/:id">
-              <DeckView />
+              <DeckView token={token} />
             </Route>
             <Route path="/deck/:deckId/add">
               <CreateCard token={token} setToken={setToken} />

--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -155,7 +155,7 @@ function DeckView({ token }) {
               {/* TODO: tooltip on hover disabled to explain why disabled */}
               <DarkButton
                 btnText="Add Card"
-                linkTo={`${id}/add`}
+                linkTo={`add`}
                 disabled={!permissions.canAddCard}
               />
             </div>

--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -73,6 +73,8 @@ function DeckView({ token }) {
         .catch((err) => {
           console.log("!!", err);
         });
+    } else {
+      setIsPermissionsLoaded(true);
     }
   }, [token]);
 

--- a/front-end/src/views/DeckView.jsx
+++ b/front-end/src/views/DeckView.jsx
@@ -7,13 +7,20 @@ import { useEffect } from "react";
 import LoadingSpinner from "../common/spinner/LoadingSpinner";
 import share from "../assets/share.png";
 
-function DeckView() {
+function DeckView({ token }) {
   const CARD_LIMIT = 9;
   let { id } = useParams();
   const [page, setPage] = useState(0);
   const [hasNextPage, setHasNextPage] = useState(true);
   const [isFetchingMoreCards, setIsFetchingMoreCards] = useState(false);
   const [isDeckLoaded, setIsDeckLoaded] = useState(false);
+  const [isPermissionsLoaded, setIsPermissionsLoaded] = useState(false);
+
+  const [permissions, setPermissions] = useState({
+    canAddCard: true,
+    isDeckOwner: false,
+  });
+
   const [deck, setDeck] = useState({
     deckName: "Untitled",
     deckDescription: "",
@@ -54,7 +61,22 @@ function DeckView() {
 
   // handles the behavior when the page first loads
   useEffect(() => {
-    // fetches the first batch of cards from the API
+    if (token) {
+      axios
+        .get(`http://localhost:8000/deck/deckPermissions/${id}`, {
+          headers: { Authorization: `JWT ${token}` },
+        })
+        .then((res) => {
+          setPermissions(res.data);
+          setIsPermissionsLoaded(true);
+        })
+        .catch((err) => {
+          console.log("!!", err);
+        });
+    }
+  }, [token]);
+
+  useEffect(() => {
     axios
       .get(`http://localhost:8000/deck/${id}?page=${page}&limit=${CARD_LIMIT}`)
       .then((res) => {
@@ -81,7 +103,9 @@ function DeckView() {
 
   function deleteDeck() {
     axios
-      .delete(`http://localhost:8000/deck/${id}`)
+      .delete(`http://localhost:8000/deck/${id}`, {
+        headers: { Authorization: `JWT ${token}` },
+      })
       .then(() => {
         //After deleting, redirect user back to homepage.
         alert("You've just deleted a deck!");
@@ -102,9 +126,7 @@ function DeckView() {
     }, 3000);
   }
 
-  return !isDeckLoaded ? (
-    <LoadingSpinner />
-  ) : (
+  return isDeckLoaded && isPermissionsLoaded ? (
     <div className="deckview-overall">
       <div className="header">
         <div className="title-container">
@@ -117,14 +139,23 @@ function DeckView() {
           </div>
           {/* TODO: only show button for admin */}
           <div className="deckview-buttons">
-            <div className="edit">
-              <Button btnText="Edit Deck" linkTo={`${id}/edit`} />
-            </div>
-            <div className="delete">
-              <Button btnText="Delete Deck" onClick={() => deleteDeck()} />
-            </div>
+            {permissions.isDeckOwner && (
+              <>
+                <div className="edit">
+                  <Button btnText="Edit Deck" linkTo={`${id}/edit`} />
+                </div>
+                <div className="delete">
+                  <Button btnText="Delete Deck" onClick={() => deleteDeck()} />
+                </div>
+              </>
+            )}
             <div className="add">
-              <DarkButton btnText="Add Card" linkTo={`${id}/add`} />
+              {/* TODO: tooltip on hover disabled to explain why disabled */}
+              <DarkButton
+                btnText="Add Card"
+                linkTo={`${id}/add`}
+                disabled={!permissions.canAddCard}
+              />
             </div>
           </div>
         </div>
@@ -136,6 +167,8 @@ function DeckView() {
         ))}
       </div>
     </div>
+  ) : (
+    <LoadingSpinner />
   );
 }
 export default DeckView;

--- a/front-end/src/views/FindDeck.jsx
+++ b/front-end/src/views/FindDeck.jsx
@@ -17,7 +17,6 @@ function FindDeck() {
       .then((res) => {
         const accessCodes = res.data.map((deck) => deck.accessCode);
         const deckIds = res.data.map((deck) => deck._id);
-        console.log({ accessCodes });
         setAccessCodes(accessCodes);
         setDeckIds(deckIds);
       })

--- a/front-end/src/views/UpdateDeck.jsx
+++ b/front-end/src/views/UpdateDeck.jsx
@@ -5,7 +5,7 @@ import { Redirect, useParams } from "react-router-dom";
 import LoadingSpinner from "../common/spinner/LoadingSpinner";
 
 // TODO: restrict page to deck owner
-function UpdateDeck() {
+function UpdateDeck({ token }) {
   const { deckId } = useParams();
   const [isDeckLoaded, setIsDeckLoaded] = useState(false);
   const [deckName, setDeckName] = useState();
@@ -28,10 +28,16 @@ function UpdateDeck() {
 
   const updateDeckWithRedirect = () => {
     axios
-      .patch(`http://localhost:8000/deck/${deckId}`, {
-        deckName: deckName,
-        deckDescription: deckDescription,
-      })
+      .patch(
+        `http://localhost:8000/deck/${deckId}`,
+        {
+          deckName: deckName,
+          deckDescription: deckDescription,
+        },
+        {
+          headers: { Authorization: `JWT ${token}` },
+        }
+      )
       .then(() => {
         setRedirect(true);
       })


### PR DESCRIPTION
this PR finishes up #134 
- establishes a new /deck/deckPermissions/:id endpoint that returns the following information for a logged-in user: {canAddCard, isDeckOwner}
- only renders edit/delete deck buttons if is DeckOwner
- disables add card button if cannot add card
<img width="1324" alt="Screen Shot 2021-11-18 at 4 20 16 PM" src="https://user-images.githubusercontent.com/52385987/142498503-80314d15-5d9c-475f-98d3-3a85ff1068c5.png">
<img width="1343" alt="Screen Shot 2021-11-18 at 4 20 30 PM" src="https://user-images.githubusercontent.com/52385987/142498505-16558acb-5e28-4944-aa08-2a7e6dbc5070.png">

