### PR TITLE
restrict shortid characters to alphanum

### DIFF
--- a/back-end/controllers/deckController.js
+++ b/back-end/controllers/deckController.js
@@ -1,8 +1,11 @@
 const mongose = require("mongoose");
-const ObjectId = mongose.Types.ObjectId;
 const shortid = require("shortid");
 const jwt = require("jsonwebtoken");
 const { validationResult } = require("express-validator");
+
+shortid.characters(
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+);
 
 const db = require("../db.js");
 const User = require("../models/user");


### PR DESCRIPTION
previously, our generated deck access codes could have - or _ which makes it hard for a user to manually copy paste the whole code

with this PR, the generated code will only contain alphanumeric characters